### PR TITLE
Metric logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.egg-info
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,0 +1,32 @@
+metricslog
+===========
+
+Logs metrics to /var/log/metrics.log. These metrics take the format:
+
+```json
+{"timestamp": "YYYY-mm-ddTHH:MM:SS", "host": "host01", "service": "users", "metric":"foo.bar", "value": 1.0}
+```
+
+
+If you have the SERVICE_NAME and HOSTNAME environment variables set, then these fields would also be logged with the metric.
+
+If it is not set, you can also pass it when initializing the logger.
+
+```python
+
+In [1]: import metricslog
+
+In [2]: log = metricslog.Logger()
+
+In [3]: log.emit(metric="user_created")
+{"timestamp": "2017-01-91T00:00:00Z", "hostname": "production-i-02332", "service": "users", "metric":"user_created", "value": 1.0}
+
+In [4]: log = metricslog.Logger(service="offers", hostname="production-i-02332")
+
+In [5]: log.emit(metric="user_created", value=1.0)
+{"timestamp": "2017-01-91T00:00:00Z", "hostname": "production-i-02332", "service": "offers", "metric":"user_created", "value": 1.0}
+
+
+```
+
+License: MIT

--- a/metricslog.py
+++ b/metricslog.py
@@ -1,0 +1,27 @@
+import os
+import logging
+from datetime import datetime
+
+from structlog import PrintLogger
+from structlog import wrap_logger
+from structlog.processors import JSONRenderer
+
+
+
+def add_metadata(_, __, event_dict):
+    event_dict['timestamp'] = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    return event_dict
+
+
+class Logger(object):
+    def __init__(self, output=None, service=None, hostname=None):
+        output = output or open('/var/log/metrics.log', "a")
+        self.service = service or os.environ.get('SERVICE_NAME')
+        self.hostname = hostname or os.environ.get('HOSTNAME')
+        self._log = wrap_logger(
+                        PrintLogger(output),
+                        processors=[add_metadata, JSONRenderer()])
+
+    def emit(self, metric, value=1.0):
+        return self._log.info(metric=metric, value=value,
+                              service=self.service, hostname=self.hostname)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from setuptools import setup
+
+setup(
+    name='metricslog',
+    version='0.1.0',
+    py_modules=['metricslog'],
+    install_requires=[
+        'structlog==15.0.0',
+    ],
+    zip_safe=False,
+)

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,43 @@
+import json
+from mock import ANY
+from cStringIO import StringIO
+from metricslog import Logger
+
+
+class TestMetricLogObserver(object):
+    def setup(self):
+        self.out = StringIO()
+        self.service = 'myservice'
+        self.hostname = 'host-01'
+        self.log = Logger(self.out, service=self.service, hostname=self.hostname)
+
+    def test_emit(self):
+        metric = 'user_created'
+        value = 10.0
+        self.log.emit(metric, value)
+        self.assert_output({
+            "timestamp": ANY,
+            "service": self.service,
+            "hostname": self.hostname,
+            "metric": metric,
+            "value": value
+        })
+
+    def test_emit_with_default_value(self):
+        metric = 'user_created'
+        self.log.emit(metric)
+        self.assert_output({
+            "timestamp": ANY,
+            "service": self.service,
+            "hostname": self.hostname,
+            "metric": metric,
+            "value": 1.0
+        })
+
+    def get_output(self):
+        self.out.reset()
+        return json.loads(self.out.read())
+
+    def assert_output(self, expected):
+        actual = self.get_output()
+        assert actual == expected, repr(actual)


### PR DESCRIPTION
Logs metrics to /var/log/metrics.log. These metrics take the format:

```json
{"timestamp": "YYYY-mm-ddTHH:MM:SS", "host": "host01", "service": "users", "metric":"foo.bar", "value": 1.0}
```


If you have the SERVICE_NAME and HOSTNAME environment variables set, then these fields would also be logged with the metric.

If it is not set, you can also pass it when initializing the logger.

```python

In [1]: import metricslog

In [2]: log = metricslog.Logger()

In [3]: log.emit(metric="user_created")
{"timestamp": "2017-01-91T00:00:00Z", "hostname": "production-i-02332", "service": "users", "metric":"user_created", "value": 1.0}

In [4]: log = metricslog.Logger(service="offers", hostname="production-i-02332")

In [5]: log.emit(metric="user_created", value=1.0)
{"timestamp": "2017-01-91T00:00:00Z", "hostname": "production-i-02332", "service": "offers", "metric":"user_created", "value": 1.0}


```